### PR TITLE
Garantía de calidad

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
   qa:
     needs: test
     runs-on: self-hosted
-    continue-on-error: github.ref != 'refs/heads/main'
+    continue-on-error: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: calidad-codigo
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
   qa:
     needs: test
     runs-on: self-hosted
-    continue-on-error: true # It is not so important having quality problems to stop the deployment
+    continue-on-error: github.ref != 'refs/heads/main'
     steps:
       - name: calidad-codigo
         run: |


### PR DESCRIPTION
Ahora, se bloquea el despliegue al entorno de producción cuando la calidad de código no es suficiente según resultado de Sonarqube.

En pre-producción u otros desarrollos, no se aplica eso.